### PR TITLE
v0.11.5 and backported patch

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,8 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,6 +1,8 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ Home: https://github.com/PyO3/setuptools-rust
 
 Package license: MIT
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/setuptools-rust-feedstock/blob/master/LICENSE.txt)
 
 Summary: Setuptools rust extension plugin
-
-
 
 Current build status
 ====================

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/s/setuptools-rust/setuptools-rust-{{ version }}.tar.gz
   sha256: 04ea21f1bd029046fb87d098be4d7dc74663a58dd1f9fc6edcf8f3e4123ec4a8
+  patches:
+    - pr90.patch
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "setuptools-rust" %}
-{% set version = "0.11.3" %}
+{% set version = "0.11.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/setuptools-rust/setuptools-rust-{{ version }}.tar.gz
-  sha256: 2168710dc9ff7a9d74a4a103588e09782ac5f92ae2211fd93df5a4700ed741dc
+  sha256: 04ea21f1bd029046fb87d098be4d7dc74663a58dd1f9fc6edcf8f3e4123ec4a8
 
 build:
   noarch: python
   number: 0
-  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv '
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -29,6 +29,10 @@ requirements:
 test:
   imports:
     - setuptools_rust
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/PyO3/setuptools-rust

--- a/recipe/pr90.patch
+++ b/recipe/pr90.patch
@@ -1,0 +1,55 @@
+From 060d8b4b4ad5f3a5173466a2f47ea74eda70f6e7 Mon Sep 17 00:00:00 2001
+From: Markus Gerstel <markus.gerstel@diamond.ac.uk>
+Date: Sat, 14 Nov 2020 17:42:27 +0000
+Subject: [PATCH 1/2] Use target CARGO_BUILD_TARGET if specified
+
+rust will pick up the environment variable anyway, but if we don't pick
+up on it, too, then we won't find the build artifacts.
+---
+ setuptools_rust/build.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/setuptools_rust/build.py b/setuptools_rust/build.py
+index 907fb60..e452823 100644
+--- a/setuptools_rust/build.py
++++ b/setuptools_rust/build.py
+@@ -92,10 +92,14 @@ def build_extension(self, ext):
+ 
+         # If we are on a 64-bit machine, but running a 32-bit Python, then
+         # we'll target a 32-bit Rust build.
++        # Automatic target detection can be overridden via the CARGO_BUILD_TARGET
++        # environment variable.
+         # TODO: include --target for all platforms so env vars can't break the build
+         target_triple = None
+         target_args = []
+-        if self.plat_name == "win32":
++        if os.getenv("CARGO_BUILD_TARGET"):
++            target_triple = os.environ["CARGO_BUILD_TARGET"]
++        elif self.plat_name == "win32":
+             target_triple = "i686-pc-windows-msvc"
+         elif self.plat_name == "win-amd64":
+             target_triple = "x86_64-pc-windows-msvc"
+
+From 3cd83ecad88b16d2c574ce57380b290623aff18c Mon Sep 17 00:00:00 2001
+From: David Hewitt <1939362+davidhewitt@users.noreply.github.com>
+Date: Sun, 15 Nov 2020 19:23:22 +0000
+Subject: [PATCH 2/2] Add changelog entry for #90
+
+---
+ CHANGELOG.md | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index 04fb861..e8268c7 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -1,5 +1,9 @@
+ # Changelog
+ 
++## Unreleased
++
++ - Respect `CARGO_BUILD_TARGET` environment variable if set. [#90](https://github.com/PyO3/setuptools-rust/pull/90)
++
+ ## 0.11.5 (2020-11-10)
+ 
+  - Fix support for Python 3.5. [#86](https://github.com/PyO3/setuptools-rust/pull/86)


### PR DESCRIPTION
Update to the current release and include an additional backported PR PyO3/setuptools-rust#90, which should fix the downstream conda-forge build conda-forge/tokenizers-feedstock#8

closes #6, closes #7 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
